### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ progressLayout:progress="true|false" indicates, will progress bar visible, after
     }
 ```
 
-##Developed By
+## Developed By
 
   Anton Krasov - <anton.krasov@gmail.com>
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
